### PR TITLE
Github action for pre-commit

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,16 @@
+on:
+  pull_request:
+  push:
+    branches: [main, gh-action-pre-commit, test-me-*]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.x
+    - uses: pre-commit/action@v3.0.0
+    - uses: pre-commit-ci/lite-action@v1.0.1
+      if: always()

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,7 +1,7 @@
 on:
   pull_request:
   push:
-    branches: [main, gh-action-pre-commit, test-me-*]
+    branches: [main]
 
 jobs:
   main:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.x
+        python-version: 3.11
     - uses: pre-commit/action@v3.0.0
     - uses: pre-commit-ci/lite-action@v1.0.1
       if: always()


### PR DESCRIPTION
For obvious reasons, this builds on top of #8. It also needs [this setup](https://pre-commit.ci/lite.html) on your repo/account. Seems to work like a charm, although admittedly it seems a bit useless in our case where we are relatively certain that all developers are willing to use pre-commit anyways.