### PR TITLE
Performance read binary

### DIFF
--- a/glue_analysis/auxiliary.py
+++ b/glue_analysis/auxiliary.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+NUMBERS = "0123456789"

--- a/glue_analysis/correlator.py
+++ b/glue_analysis/correlator.py
@@ -152,7 +152,7 @@ class CorrelatorEnsemble:
             if "Columns with duplicate values are not supported in stack" in str(ex):
                 # see https://github.com/unionai-oss/pandera/issues/1328
                 raise ValueError(message) from ex
-            raise
+            raise  # pragma: no cover
         if hasattr(self, "_vevs"):
             try:
                 VEVData.validate(self._vevs)
@@ -162,7 +162,7 @@ class CorrelatorEnsemble:
                 ):
                     # see https://github.com/unionai-oss/pandera/issues/1328
                     raise ValueError(message) from ex
-                raise
+                raise  # pragma: no cover
             cross_validate(self._correlators, self._vevs)
         self._frozen = True
         return self

--- a/glue_analysis/correlator.py
+++ b/glue_analysis/correlator.py
@@ -8,6 +8,8 @@ import pandera as pa
 import pyerrors as pe
 from pandera.typing import DataFrame as DataFrameType
 
+from glue_analysis.auxiliary import NUMBERS
+
 _COLUMN_DESCRIPTIONS = {
     #
     "MC_Time": "Index enumerating the Monte Carlo samples.",
@@ -37,14 +39,12 @@ CorrelatorData = pa.DataFrameSchema(
     },
     index=pa.MultiIndex(
         [
-            pa.Index(int, description=_COLUMN_DESCRIPTIONS["MC_Time"], name="MC_Time"),
             pa.Index(
-                int, description=_COLUMN_DESCRIPTIONS["Internal"], name="Internal1"
-            ),
-            pa.Index(
-                int, description=_COLUMN_DESCRIPTIONS["Internal"], name="Internal2"
-            ),
-            pa.Index(int, description=_COLUMN_DESCRIPTIONS["Time"], name="Time"),
+                int,
+                description=_COLUMN_DESCRIPTIONS[column.strip(NUMBERS)],
+                name=column,
+            )
+            for column in ("MC_Time", "Internal1", "Internal2", "Time")
         ],
         strict=True,
         ordered=False,
@@ -69,10 +69,8 @@ VEVData = pa.DataFrameSchema(
     },
     index=pa.MultiIndex(
         [
-            pa.Index(int, description=_COLUMN_DESCRIPTIONS["MC_Time"], name="MC_Time"),
-            pa.Index(
-                int, description=_COLUMN_DESCRIPTIONS["Internal"], name="Internal"
-            ),
+            pa.Index(int, description=_COLUMN_DESCRIPTIONS[column], name=column)
+            for column in ("MC_Time", "Internal")
         ],
         strict=True,
         ordered=False,

--- a/glue_analysis/readers/read_binary.py
+++ b/glue_analysis/readers/read_binary.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from functools import lru_cache
 from pathlib import Path
 from typing import Any, BinaryIO
 
@@ -33,7 +32,6 @@ class ParsingError(Exception):
     pass
 
 
-@lru_cache(maxsize=8)
 def read_correlators_binary(
     corr_filename: str,
     vev_filename: str | None = None,

--- a/glue_analysis/readers/read_binary.py
+++ b/glue_analysis/readers/read_binary.py
@@ -155,16 +155,10 @@ def _read_header(corr_file: BinaryIO) -> dict[str, int]:
 
 
 def _columns_from_header(header: dict[str, int], columns: list[str]) -> pd.DataFrame:
-    return (
-        pd.MultiIndex.from_product(
-            [
-                range(
-                    1, LENGTH_OF_CORRELATOR_INDEXING[column.strip(NUMBERS)](header) + 1
-                )
-                for column in columns
-            ],
-            names=columns,
-        )
-        .to_frame()
-        .reset_index(drop=True)
-    )
+    return pd.MultiIndex.from_product(
+        [
+            range(1, LENGTH_OF_CORRELATOR_INDEXING[column.strip(NUMBERS)](header) + 1)
+            for column in columns
+        ],
+        names=columns,
+    ).to_frame(index=False)

--- a/glue_analysis/readers/read_binary.py
+++ b/glue_analysis/readers/read_binary.py
@@ -57,13 +57,13 @@ def _read_correlators_binary(
     correlators.metadata = _assemble_metadata(corr_file, metadata)
     correlators.correlators = _read(
         corr_file,
-        _columns_from_header(correlators.metadata, CORRELATOR_INDEXING_COLUMNS),
+        _index_from_header(correlators.metadata, CORRELATOR_INDEXING_COLUMNS),
         CORRELATOR_VALUE_COLUMN_NAME,
     )
     if vev_file:
         correlators.vevs = _read(
             vev_file,
-            _columns_from_header(correlators.metadata, VEV_INDEXING_COLUMNS),
+            _index_from_header(correlators.metadata, VEV_INDEXING_COLUMNS),
             VEV_VALUE_COLUMN_NAME,
         )
 
@@ -131,7 +131,7 @@ def _read_header(corr_file: BinaryIO) -> dict[str, int]:
     return header
 
 
-def _columns_from_header(header: dict[str, int], columns: list[str]) -> pd.MultiIndex:
+def _index_from_header(header: dict[str, int], columns: list[str]) -> pd.MultiIndex:
     return pd.MultiIndex.from_product(
         [
             range(1, LENGTH_OF_CORRELATOR_INDEXING[column.strip(NUMBERS)](header) + 1)

--- a/glue_analysis/readers/read_binary.py
+++ b/glue_analysis/readers/read_binary.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, BinaryIO
 
@@ -32,6 +33,7 @@ class ParsingError(Exception):
     pass
 
 
+@lru_cache(maxsize=8)
 def read_correlators_binary(
     corr_filename: str,
     vev_filename: str | None = None,

--- a/glue_analysis/readers/read_binary.py
+++ b/glue_analysis/readers/read_binary.py
@@ -5,6 +5,7 @@ from typing import Any, BinaryIO
 import numpy as np
 import pandas as pd
 
+from glue_analysis.auxiliary import NUMBERS
 from glue_analysis.correlator import CorrelatorEnsemble
 
 LENGTH_OF_CORRELATOR_INDEXING = {
@@ -19,7 +20,6 @@ CORRELATOR_INDEXING_COLUMNS = [
     "Internal2",
     "Time",
 ]
-NUMBERS = "0123456789"
 CORRELATOR_VALUE_COLUMN_NAME = "Correlation"
 VEV_VALUE_COLUMN_NAME = "Vac_exp"
 VEV_INDEXING_COLUMNS = ["MC_Time", "Internal"]

--- a/glue_analysis/readers/read_binary.py
+++ b/glue_analysis/readers/read_binary.py
@@ -67,13 +67,6 @@ def _read_correlators_binary(
             VEV_VALUE_COLUMN_NAME,
         )
 
-    # Adding `perform_expensive_validation=False` is untested because
-    # 1) it is internal behaviour that should not matter to the caller
-    # 2) I can't think of a way to make a failing test here (which is probably a
-    #    very good sign concerning the safety of the modification itself)
-    # 3) Any way to test this I can come up with involves messing with ugly
-    #    mocks or the like and I think it would neither improve code quality nor
-    #    mental health of the author to do so.
     return correlators.freeze(perform_expensive_validation=False)
 
 

--- a/glue_analysis/readers/read_binary.py
+++ b/glue_analysis/readers/read_binary.py
@@ -74,7 +74,7 @@ def _read(
     file: BinaryIO,
     # could be more precise, i.e., only indexing portion of
     # DataFrameType[CorrelatorData | VEVData]:
-    index: pd.DataFrame,
+    index: pd.MultiIndex,
     value_column_name: str,
 ) -> pd.DataFrame:
     file.seek(HEADER_LENGTH)
@@ -131,7 +131,7 @@ def _read_header(corr_file: BinaryIO) -> dict[str, int]:
     return header
 
 
-def _columns_from_header(header: dict[str, int], columns: list[str]) -> pd.DataFrame:
+def _columns_from_header(header: dict[str, int], columns: list[str]) -> pd.MultiIndex:
     return pd.MultiIndex.from_product(
         [
             range(1, LENGTH_OF_CORRELATOR_INDEXING[column.strip(NUMBERS)](header) + 1)

--- a/glue_analysis/readers/read_binary.py
+++ b/glue_analysis/readers/read_binary.py
@@ -66,7 +66,15 @@ def _read_correlators_binary(
             _columns_from_header(correlators.metadata, VEV_INDEXING_COLUMNS),
             VEV_VALUE_COLUMN_NAME,
         )
-    return correlators.freeze()
+
+    # Adding `perform_expensive_validation=False` is untested because
+    # 1) it is internal behaviour that should not matter to the caller
+    # 2) I can't think of a way to make a failing test here (which is probably a
+    #    very good sign concerning the safety of the modification itself)
+    # 3) Any way to test this I can come up with involves messing with ugly
+    #    mocks or the like and I think it would neither improve code quality nor
+    #    mental health of the author to do so.
+    return correlators.freeze(perform_expensive_validation=False)
 
 
 def _read(

--- a/glue_analysis/readers/read_binary.py
+++ b/glue_analysis/readers/read_binary.py
@@ -73,13 +73,17 @@ def _read(
     file: BinaryIO,
     # could be more precise, i.e., only indexing portion of
     # DataFrameType[CorrelatorData | VEVData]:
-    correlators: pd.DataFrame,
+    index: pd.DataFrame,
     value_column_name: str,
 ) -> pd.DataFrame:
     file.seek(HEADER_LENGTH)
-    correlators[value_column_name] = (
-        # Should be np.fromfile but workaround for https://github.com/numpy/numpy/issues/2230
-        np.frombuffer(file.read(), dtype=np.float64)
+    correlators = pd.DataFrame(
+        {
+            value_column_name:
+            # Should be np.fromfile but workaround for https://github.com/numpy/numpy/issues/2230
+            np.frombuffer(file.read(), dtype=np.float64)
+        },
+        index=index,
     )
     file.seek(0)
     return correlators
@@ -133,4 +137,4 @@ def _columns_from_header(header: dict[str, int], columns: list[str]) -> pd.DataF
             for column in columns
         ],
         names=columns,
-    ).to_frame(index=False)
+    )

--- a/glue_analysis/readers/read_fortran.py
+++ b/glue_analysis/readers/read_fortran.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 from copy import deepcopy
 from functools import lru_cache
 from pathlib import Path

--- a/test/test_correlator.py
+++ b/test/test_correlator.py
@@ -498,15 +498,12 @@ def test_correlator_ensemble_fails_if_vevs_and_correlators_with_different_length
     unfrozen_corr_ensemble: CorrelatorEnsemble,
 ) -> None:
     unfrozen_corr_ensemble.vevs = (
-        unfrozen_corr_ensemble.vevs.droplevel("MC_Time")
-        .assign(MC_Time=-1)
-        .set_index("MC_Time", append=True)
-    )  # different from correlators
-    unfrozen_corr_ensemble.vevs = (
         unfrozen_corr_ensemble.vevs.reset_index(drop=False)
+        .assign(MC_Time=-1)
         .drop_duplicates(subset=["MC_Time", "Internal"], keep="first")
         .set_index(["MC_Time", "Internal"])
     )
+    # now vevs is shorter (but still has a consistent index not triggering other checks)
     with pytest.raises(DataInconsistencyError):
         unfrozen_corr_ensemble.freeze()
 
@@ -515,18 +512,14 @@ def test_correlator_ensemble_fails_if_vevs_and_correlators_with_different_index(
     unfrozen_corr_ensemble: CorrelatorEnsemble,
 ) -> None:
     unfrozen_corr_ensemble.vevs = (
-        unfrozen_corr_ensemble.vevs.droplevel("MC_Time")
-        .assign(MC_Time=-1)
-        .set_index("MC_Time", append=True)
-    )  # different from correlators
-    unfrozen_corr_ensemble.vevs = (
         unfrozen_corr_ensemble.vevs.reset_index(drop=False)
+        .assign(MC_Time=-1)
         .drop_duplicates(subset=["MC_Time", "Internal"], keep="first")
         .set_index(["MC_Time", "Internal"])
-    )
+    )  # now MC_Time is different from any corresponding values in correlators
     unfrozen_corr_ensemble.correlators = unfrozen_corr_ensemble.correlators.loc(axis=0)[
         1, ...
-    ]
+    ]  # now correlators has the same length as vevs
     with pytest.raises(DataInconsistencyError):
         unfrozen_corr_ensemble.freeze()
 

--- a/test/test_correlator.py
+++ b/test/test_correlator.py
@@ -28,8 +28,9 @@ MC_TIME_AXIS = 0
 
 @pytest.fixture()
 def corr_data() -> CorrelatorData:
-    return (
-        pd.MultiIndex.from_product(
+    return pd.DataFrame(
+        {"Correlation": np.arange(CORRELATOR_DATA_LENGTH, dtype=float)},
+        index=pd.MultiIndex.from_product(
             [
                 range(1, LENGTH_MC_TIME + 1),
                 range(1, LENGTH_TIME + 1),
@@ -37,10 +38,7 @@ def corr_data() -> CorrelatorData:
                 range(1, LENGTH_INTERNAL + 1),
             ],
             names=["MC_Time", "Time", "Internal1", "Internal2"],
-        )
-        .to_frame()
-        .reset_index(drop=True)
-        .assign(Correlation=np.arange(CORRELATOR_DATA_LENGTH, dtype=float))
+        ),
     )
 
 

--- a/test/test_correlator.py
+++ b/test/test_correlator.py
@@ -531,3 +531,23 @@ def test_correlator_ensemble_fails_if_vevs_and_correlators_with_different_index(
     ]
     with pytest.raises(DataInconsistencyError):
         unfrozen_corr_ensemble.freeze()
+
+
+def test_correlator_ensemble_can_freeze_without_validation(
+    unfrozen_corr_ensemble: CorrelatorEnsemble,
+) -> None:
+    unfrozen_corr_ensemble.correlators = pd.DataFrame(
+        ["rubbish that would fail validation"]
+    )
+    unfrozen_corr_ensemble.freeze(perform_expensive_validation=False)
+    # Let's check this despite the fact that reaching this line without an
+    # exception raised likely means we've done it:
+    assert unfrozen_corr_ensemble.frozen
+
+
+def test_correlator_ensemble_freezing_without_validation_still_performs_typecheck(
+    unfrozen_corr_ensemble: CorrelatorEnsemble,
+) -> None:
+    unfrozen_corr_ensemble.correlators = "rubbish that would fail validation"
+    with pytest.raises(TypeError):
+        unfrozen_corr_ensemble.freeze(perform_expensive_validation=False)

--- a/test/test_correlator.py
+++ b/test/test_correlator.py
@@ -183,7 +183,7 @@ def test_correlator_ensemble_returns_correct_numpy_data(
     frozen_corr_ensemble: CorrelatorEnsemble,
 ) -> None:
     assert (
-        frozen_corr_ensemble.get_numpy().reshape(-1)
+        frozen_corr_ensemble.get_numpy().ravel()
         == frozen_corr_ensemble.correlators["Correlation"].to_numpy()
     ).all()
 
@@ -195,7 +195,7 @@ def test_correlator_ensemble_returns_sorted_numpy_data(
     unfrozen_corr_ensemble.correlators = unfrozen_corr_ensemble.correlators.sample(
         frac=1
     )
-    assert (unfrozen_corr_ensemble.freeze().get_numpy().reshape(-1) == expected).all()
+    assert (unfrozen_corr_ensemble.freeze().get_numpy().ravel() == expected).all()
 
 
 def test_correlator_ensemble_returns_correctly_shaped_numpy_vevs(
@@ -211,7 +211,7 @@ def test_correlator_ensemble_returns_correct_numpy_data_for_vevs(
     frozen_corr_ensemble: CorrelatorEnsemble,
 ) -> None:
     assert (
-        frozen_corr_ensemble.get_numpy_vevs().reshape(-1)
+        frozen_corr_ensemble.get_numpy_vevs().ravel()
         == frozen_corr_ensemble.vevs["Vac_exp"].to_numpy()
     ).all()
 
@@ -221,9 +221,7 @@ def test_correlator_ensemble_returns_sorted_numpy_data_for_vevs(
 ) -> None:
     expected = unfrozen_corr_ensemble.vevs["Vac_exp"].to_numpy()
     unfrozen_corr_ensemble.vevs = unfrozen_corr_ensemble.vevs.sample(frac=1)
-    assert (
-        unfrozen_corr_ensemble.freeze().get_numpy_vevs().reshape(-1) == expected
-    ).all()
+    assert (unfrozen_corr_ensemble.freeze().get_numpy_vevs().ravel() == expected).all()
 
 
 def test_correlator_ensemble_raises_for_subtract_without_vevs_present(

--- a/test/test_correlator.py
+++ b/test/test_correlator.py
@@ -496,6 +496,23 @@ def test_correlator_ensemble_fails_if_indexing_rows_are_not_unique_vevs(
         unfrozen_corr_ensemble.freeze()
 
 
+def test_correlator_ensemble_fails_if_vevs_and_correlators_with_different_length_index(
+    unfrozen_corr_ensemble: CorrelatorEnsemble,
+) -> None:
+    unfrozen_corr_ensemble.vevs = (
+        unfrozen_corr_ensemble.vevs.droplevel("MC_Time")
+        .assign(MC_Time=-1)
+        .set_index("MC_Time", append=True)
+    )  # different from correlators
+    unfrozen_corr_ensemble.vevs = (
+        unfrozen_corr_ensemble.vevs.reset_index(drop=False)
+        .drop_duplicates(subset=["MC_Time", "Internal"], keep="first")
+        .set_index(["MC_Time", "Internal"])
+    )
+    with pytest.raises(DataInconsistencyError):
+        unfrozen_corr_ensemble.freeze()
+
+
 def test_correlator_ensemble_fails_if_vevs_and_correlators_with_different_index(
     unfrozen_corr_ensemble: CorrelatorEnsemble,
 ) -> None:
@@ -509,5 +526,8 @@ def test_correlator_ensemble_fails_if_vevs_and_correlators_with_different_index(
         .drop_duplicates(subset=["MC_Time", "Internal"], keep="first")
         .set_index(["MC_Time", "Internal"])
     )
+    unfrozen_corr_ensemble.correlators = unfrozen_corr_ensemble.correlators.loc(axis=0)[
+        1, ...
+    ]
     with pytest.raises(DataInconsistencyError):
         unfrozen_corr_ensemble.freeze()

--- a/test/test_correlator.py
+++ b/test/test_correlator.py
@@ -472,8 +472,7 @@ def test_correlator_ensemble_fails_if_indexing_rows_are_not_unique(
     unfrozen_corr_ensemble.correlators.index = pd.MultiIndex.from_frame(idx)
     message = (
         "Non-unique index, "
-        "should be pa.errors.SchemaError "
-        "but fails due to some incompatibility."
+        "should be pa.errors.SchemaError but fails due to some incompatibility."
     )
     with pytest.raises(ValueError, match=message):
         unfrozen_corr_ensemble.freeze()
@@ -487,8 +486,7 @@ def test_correlator_ensemble_fails_if_indexing_rows_are_not_unique_vevs(
     unfrozen_corr_ensemble.vevs.index = pd.MultiIndex.from_frame(idx)
     message = (
         "Non-unique index, "
-        "should be pa.errors.SchemaError "
-        "but fails due to some incompatibility."
+        "should be pa.errors.SchemaError but fails due to some incompatibility."
     )
     with pytest.raises(ValueError, match=message):
         unfrozen_corr_ensemble.freeze()

--- a/test/test_read_binary.py
+++ b/test/test_read_binary.py
@@ -36,13 +36,9 @@ def columns_from_header(header: dict[str, int], *, vev: bool = False) -> pd.Data
             range(1, header["Nop"] * header["Nbl"] + 1),
             range(1, int(header["LT"] / 2 + 1) + 1),
         ]
-    return (
-        pd.MultiIndex.from_product(
-            index_ranges,
-            names=VEV_INDEXING_COLUMNS if vev else CORRELATOR_INDEXING_COLUMNS,
-        )
-        .to_frame()
-        .reset_index(drop=True)
+    return pd.MultiIndex.from_product(
+        index_ranges,
+        names=VEV_INDEXING_COLUMNS if vev else CORRELATOR_INDEXING_COLUMNS,
     )
 
 

--- a/test/test_read_binary.py
+++ b/test/test_read_binary.py
@@ -28,49 +28,21 @@ def header() -> dict[str, int]:
 
 def columns_from_header(header: dict[str, int], *, vev: bool = False) -> pd.DataFrame:
     index_ranges = [
-        range(1, header["Nbin"] + 1),  # Bin_index
-        range(1, header["Nbl"] + 1),  # Blocking_index1
-        range(1, header["Nop"] + 1),  # Op_index1
+        range(1, header["Nbin"] + 1),
+        range(1, header["Nop"] * header["Nbl"] + 1),
     ]
     if not vev:
         index_ranges += [
-            range(1, header["Nbl"] + 1),  # Blocking_index2
-            range(1, header["Nop"] + 1),  # Op_index2
-            range(1, int(header["LT"] / 2 + 1) + 1),  # Time
+            range(1, header["Nop"] * header["Nbl"] + 1),
+            range(1, int(header["LT"] / 2 + 1) + 1),
         ]
-    ungrouped_columns = (
+    return (
         pd.MultiIndex.from_product(
             index_ranges,
             names=VEV_INDEXING_COLUMNS if vev else CORRELATOR_INDEXING_COLUMNS,
         )
         .to_frame()
         .reset_index(drop=True)
-    )
-    if vev:
-        assignments = {
-            "Internal": list(
-                ungrouped_columns[["Internal", "Blocking_index"]].itertuples(
-                    index=False
-                )
-            )
-        }
-    else:
-        assignments = {
-            "Internal1": list(
-                ungrouped_columns[["Internal1", "Blocking_index1"]].itertuples(
-                    index=False
-                )
-            ),
-            "Internal2": list(
-                ungrouped_columns[["Internal2", "Blocking_index2"]].itertuples(
-                    index=False
-                )
-            ),
-        }
-    return ungrouped_columns.assign(**assignments).drop(
-        ["Blocking_index", "Blocking_index1", "Blocking_index2"],
-        errors="ignore",
-        axis="columns",
     )
 
 

--- a/test/test_read_binary.py
+++ b/test/test_read_binary.py
@@ -177,11 +177,7 @@ def test_read_correlators_binary_has_indexing_columns_consistent_with_header_in_
     answer = _read_correlators_binary(
         corr_file, filename, vev_file=create_file(header, vev_data)
     )
-    assert (
-        (answer.vevs[["MC_Time", "Internal"]] == columns_from_header(header, vev=True))
-        .all()
-        .all()
-    )
+    assert (answer.vevs.index == columns_from_header(header, vev=True)).all().all()
 
 
 def test_read_correlators_binary_preserves_data_in_vev(
@@ -209,11 +205,8 @@ def test_read_correlators_binary_has_indexing_columns_consistent_with_header(
     corr_file: BinaryIO, filename: str, header: dict[str, int]
 ) -> None:
     answer = _read_correlators_binary(corr_file, filename)
-    columns = ["MC_Time", "Time", "Internal1", "Internal2"]
     assert (
-        (answer.correlators[columns] == columns_from_header(header, vev=False)[columns])
-        .all()
-        .all()
+        (answer.correlators.index == columns_from_header(header, vev=False)).all().all()
     )
 
 

--- a/test/test_read_binary.py
+++ b/test/test_read_binary.py
@@ -26,15 +26,25 @@ def header() -> dict[str, int]:
     return {name: i + 1 for i, name in enumerate(HEADER_NAMES)}
 
 
+OFFSET_FOR_1_INDEXING = 1
+
+
 def columns_from_header(header: dict[str, int], *, vev: bool = False) -> pd.DataFrame:
     index_ranges = [
-        range(1, header["Nbin"] + 1),
-        range(1, header["Nop"] * header["Nbl"] + 1),
+        range(OFFSET_FOR_1_INDEXING, header["Nbin"] + OFFSET_FOR_1_INDEXING),
+        range(
+            OFFSET_FOR_1_INDEXING, header["Nop"] * header["Nbl"] + OFFSET_FOR_1_INDEXING
+        ),
     ]
     if not vev:
         index_ranges += [
-            range(1, header["Nop"] * header["Nbl"] + 1),
-            range(1, int(header["LT"] / 2 + 1) + 1),
+            range(
+                OFFSET_FOR_1_INDEXING,
+                header["Nop"] * header["Nbl"] + OFFSET_FOR_1_INDEXING,
+            ),
+            range(
+                OFFSET_FOR_1_INDEXING, int(header["LT"] / 2 + 1) + OFFSET_FOR_1_INDEXING
+            ),
         ]
     return pd.MultiIndex.from_product(
         index_ranges,

--- a/test/test_read_binary.py
+++ b/test/test_read_binary.py
@@ -29,6 +29,10 @@ def header() -> dict[str, int]:
 OFFSET_FOR_1_INDEXING = 1
 
 
+def _correlator_length(length_in_time: int) -> int:
+    return int(length_in_time / 2 + 1)
+
+
 def columns_from_header(header: dict[str, int], *, vev: bool = False) -> pd.DataFrame:
     index_ranges = [
         range(OFFSET_FOR_1_INDEXING, header["Nbin"] + OFFSET_FOR_1_INDEXING),
@@ -43,7 +47,8 @@ def columns_from_header(header: dict[str, int], *, vev: bool = False) -> pd.Data
                 header["Nop"] * header["Nbl"] + OFFSET_FOR_1_INDEXING,
             ),
             range(
-                OFFSET_FOR_1_INDEXING, int(header["LT"] / 2 + 1) + OFFSET_FOR_1_INDEXING
+                OFFSET_FOR_1_INDEXING,
+                _correlator_length(header["LT"]) + OFFSET_FOR_1_INDEXING,
             ),
         ]
     return pd.MultiIndex.from_product(

--- a/test/test_read_binary.py
+++ b/test/test_read_binary.py
@@ -33,7 +33,7 @@ def _correlator_length(length_in_time: int) -> int:
     return int(length_in_time / 2 + 1)
 
 
-def columns_from_header(header: dict[str, int], *, vev: bool = False) -> pd.DataFrame:
+def index_from_header(header: dict[str, int], *, vev: bool = False) -> pd.MultiIndex:
     index_ranges = [
         range(OFFSET_FOR_1_INDEXING, header["Nbin"] + OFFSET_FOR_1_INDEXING),
         range(
@@ -58,7 +58,7 @@ def columns_from_header(header: dict[str, int], *, vev: bool = False) -> pd.Data
 
 
 def create_data(header: dict[str, int], *, vev: bool = False) -> np.array:
-    return np.random.random(columns_from_header(header, vev=vev).shape[0])
+    return np.random.random(index_from_header(header, vev=vev).shape[0])
 
 
 @pytest.fixture()
@@ -192,7 +192,7 @@ def test_read_correlators_binary_has_indexing_columns_consistent_with_header_in_
     answer = _read_correlators_binary(
         corr_file, filename, vev_file=create_file(header, vev_data)
     )
-    assert (answer.vevs.index == columns_from_header(header, vev=True)).all().all()
+    assert (answer.vevs.index == index_from_header(header, vev=True)).all().all()
 
 
 def test_read_correlators_binary_preserves_data_in_vev(
@@ -221,7 +221,7 @@ def test_read_correlators_binary_has_indexing_columns_consistent_with_header(
 ) -> None:
     answer = _read_correlators_binary(corr_file, filename)
     assert (
-        (answer.correlators.index == columns_from_header(header, vev=False)).all().all()
+        (answer.correlators.index == index_from_header(header, vev=False)).all().all()
     )
 
 

--- a/test/test_read_fortran.py
+++ b/test/test_read_fortran.py
@@ -147,7 +147,10 @@ def test_read_correlators_fortran_correctly_names_columns(
     full_file: TextIO, filename: str
 ) -> None:
     answer = _read_correlators_fortran(full_file, filename)
-    assert set(answer.correlators.columns) == {*CorrelatorData.columns, "channel"}
+    assert set(answer.correlators.index.names) == {
+        *CorrelatorData.index.get_metadata()[None]["columns"]
+    }
+    assert set(answer.correlators.columns) == {"Correlation", "channel"}
 
 
 def test_read_correlators_fortran_correctly_names_vev_columns(
@@ -159,7 +162,10 @@ def test_read_correlators_fortran_correctly_names_vev_columns(
     answer = _read_correlators_fortran(
         full_file, filename, vev_file=vev_file, metadata=vev_metadata
     )
-    assert set(answer.vevs.columns) == {*VEVData.columns, "channel"}
+    assert set(answer.vevs.index.names) == {
+        *VEVData.index.get_metadata()[None]["columns"]
+    }
+    assert set(answer.vevs.columns) == {"Vac_exp", "channel"}
 
 
 def test_read_correlators_fortran_preserves_data(

--- a/test/test_read_fortran.py
+++ b/test/test_read_fortran.py
@@ -173,7 +173,7 @@ def test_read_correlators_fortran_preserves_data(
 ) -> None:
     answer = _read_correlators_fortran(full_file, filename)
     assert (
-        answer.correlators.drop("channel", axis=1).to_numpy().reshape(-1) == data[:, -1]
+        answer.correlators.drop("channel", axis=1).to_numpy().ravel() == data[:, -1]
     ).all()
 
 
@@ -200,7 +200,7 @@ def test_read_correlators_fortran_preserves_normalised_data_in_vev(
     normalised_vev_data[:, -1] /= normalisation
 
     assert (
-        answer.vevs.drop("channel", axis="columns").to_numpy().reshape(-1)
+        answer.vevs.drop("channel", axis="columns").to_numpy().ravel()
         == normalised_vev_data[:, -1]
     ).all()
 

--- a/test/test_read_fortran.py
+++ b/test/test_read_fortran.py
@@ -58,7 +58,9 @@ def some_numbers() -> np.ndarray:
 
 @pytest.fixture()
 def vev_df(some_numbers: np.ndarray) -> pd.DataFrame:
-    return pd.DataFrame({"MC_Time": [1, 1, 1, 1, 1], "Vac_exp": some_numbers})
+    return pd.DataFrame(
+        {"MC_Time": [1, 1, 1, 1, 1], "Vac_exp": some_numbers}
+    ).set_index("MC_Time", append=False)
 
 
 @pytest.fixture()
@@ -164,7 +166,9 @@ def test_read_correlators_fortran_preserves_data(
     full_file: TextIO, filename: str, data: np.array
 ) -> None:
     answer = _read_correlators_fortran(full_file, filename)
-    assert (answer.correlators.drop("channel", axis=1).to_numpy() == data).all()
+    assert (
+        answer.correlators.drop("channel", axis=1).to_numpy().reshape(-1) == data[:, -1]
+    ).all()
 
 
 def test_read_correlators_fortran_preserves_normalised_data_in_vev(
@@ -190,7 +194,8 @@ def test_read_correlators_fortran_preserves_normalised_data_in_vev(
     normalised_vev_data[:, -1] /= normalisation
 
     assert (
-        answer.vevs.drop("channel", axis="columns").to_numpy() == normalised_vev_data
+        answer.vevs.drop("channel", axis="columns").to_numpy().reshape(-1)
+        == normalised_vev_data[:, -1]
     ).all()
 
 


### PR DESCRIPTION
### Description

Moving indexing columns into `pd.MultiIndex` for performance reasons which entails minor adaptions in the functional code, moderate adaptions in the validation code and major adaptions in the test data/cases. Also using an integer enumeration of operator index and blocking level index. Could be nice to provide a function that can translate, e.g., for finding a particular operator-blocking combination. But that's likely not necessary for the use case we currently have.

### Profiles

I've profiled the code
```python3
from glue_analysis.readers.read_binary import read_correlators_binary

corr_filename = "tmp.data/corr0RPpR.dat.2"  # 394MB of data
vev_filename = "tmp.data/avac0.dat.2"  # 168KB of data
correlators = read_correlators_binary(corr_filename, vev_filename)
```

Original profile was: [profile.for-PR-orig_2023-12-04_18:10.json](https://github.com/edbennett/glue_analysis/files/13549876/profile.for-PR-orig_2023-12-04_18.10.json) (view via `scalene --viewer` and browse to the downloaded `.json` file)

It's around 5min and most of the time is spent in translating the 2x 2 columns of `Internal/Blocking_index` into an index of tuples. That function also uses significant memory, together with the actual creation of the indexing columns. Scalene reports a peak of more than 16GB which is a factor of 40 compared to the input data.

New profile is: [profile.for-PR_2023-12-04_18:04.json](https://github.com/edbennett/glue_analysis/files/13550003/profile.for-PR_2023-12-04_18.04.json)

Total execution time is down to 43s. Resource consumption of `_read_correlators_binary` (without validation) is negligible by now, 2s and 800MB which is down to a factor of 2 -- likely the price we have to pay for using Python.

Memory bottlenecks are the validation steps, particularly those concerned with ensuring consistency of the internal indexing. That was not the focus of optimisations by now. Likely there are copy operations hidden in the expressions. Time-wise the cross-validation between VEV and correlator indexing seems to be the problem. It is admittedly a bit paranoid (or more positively: assumes a very general use case) to run the check for each individual timeslice and operator.